### PR TITLE
Add support for invalid certificates

### DIFF
--- a/client_get_certificate.go
+++ b/client_get_certificate.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	ssl_tool "github.com/swisscom/ssl-tool/pkg"
 	"net/url"
 )
@@ -21,7 +23,9 @@ func doGetCertificateCmd() {
 	}
 
 	certs, err := ssl_tool.GetCerts(u.String())
-	if err != nil {
+	if errors.Is(err, ssl_tool.ErrInvalidCert) {
+		fmt.Println("! Invalid Certificate")
+	} else if err != nil {
 		logger.Fatalf("unable to get certs: %v", err)
 	}
 	printCertChain(certs)

--- a/pkg/certs.go
+++ b/pkg/certs.go
@@ -1,13 +1,18 @@
 package ssl_tool
 
 import (
+	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"net/http"
+	"net/url"
 )
 
+var ErrInvalidCert = fmt.Errorf("invalid certificate")
+
 // GetCerts returns the full chain of certificates for the provided url
-func GetCerts(url string) ([]*x509.Certificate, error) {
-	req, err := http.NewRequest(http.MethodHead, url, nil)
+func GetCerts(u string) ([]*x509.Certificate, error) {
+	req, err := http.NewRequest(http.MethodHead, u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -18,11 +23,18 @@ func GetCerts(url string) ([]*x509.Certificate, error) {
 		},
 	}
 
-	// TODO: Support invalid certificates?
 	res, err := client.Do(req)
 	if err != nil {
+		switch err.(type) {
+		case *url.Error:
+			urlErrInner := err.(*url.Error).Err
+			switch urlErrInner.(type) {
+			case *tls.CertificateVerificationError:
+				return urlErrInner.(*tls.CertificateVerificationError).UnverifiedCertificates, ErrInvalidCert
+			}
+		}
 		return nil, err
+	} else {
+		return res.TLS.PeerCertificates, nil
 	}
-
-	return res.TLS.PeerCertificates, nil
 }


### PR DESCRIPTION
This PR adds support for invalid certificates in the `client get-certificate` sub command.

An invalid certificate will look like following:

```
! Invalid Certificate
Certificate
 NAME                     VALUE 
...
```